### PR TITLE
feat: support array values for filtering

### DIFF
--- a/playground/app/app.component.ts
+++ b/playground/app/app.component.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpHeaders } from "@angular/common/http";
 
 @Component({
     selector: 'my-app',
-    template: `{{tempVar}} || {{tempVar2}} || Custom format {{tempVar3}}`,
+    template: `{{tempVar}} || {{tempVar2}} || Custom format {{tempVar3}} || Array {{tempVar4}}`,
 })
 export class AppComponent {
 
@@ -13,6 +13,7 @@ export class AppComponent {
     private tempVar: string;
     private tempVar2: string;
     private tempVar3: string;
+    private tempVar4: string;
 
     constructor(private http: HttpClient) {
         //this.testEndpoint();
@@ -20,6 +21,7 @@ export class AppComponent {
         this.tempVar3 = Query.create().filter('StartDate', OperatorType.Greater, new Date(), 'YYYY-MM-DD').compile();
         Query.create().filter('StartDate', OperatorType.Greater, 123).compile();
         this.tempVar2 = Query.create().filterComplex(`StartDate gt ${new Date().toISOString()}`).compile();
+        this.tempVar4 = this.arrayFilterQuery();
     }
 
     private async testEndpoint() {
@@ -34,6 +36,14 @@ export class AppComponent {
 
         this.resp = await this.http.get(this.generatedUrl,
             { headers: x }).toPromise()
+    }
+
+    public arrayFilterQuery(): string {
+        return Query.create()
+            .filter('Id', OperatorType.Greater, 1)
+            .filter('ReferenceId', OperatorType.Eq, 'c8027a81-5f7a-4a24-87a4-eec9afe48751')
+            .filter('Status', OperatorType.Eq, ['Pending', 'Approved'])
+            .filter('Name', OperatorType.NotEqual, 'qwerty').compile();
     }
 
     public complexFilterQuery(): string {

--- a/src/objects/query.ts
+++ b/src/objects/query.ts
@@ -113,10 +113,6 @@ export class Query implements IBaseQueryActions {
             else
                 val2 = `${formatLocalIso(val2)}Z`;
         }
-        else if(Array.isArray(val2)){
-            let val = val2.map(x => this.filterInternal(field, operator, x, format));
-            val2 = `(${val.join(" or ")})`;
-        }
         else if (typeof val2 == "string" && !Query.isGuid(val2) && val2.indexOf("'") === -1) {
             val2 = `'${val2}'`;
         }


### PR DESCRIPTION
Support array values for filtering
Example:
`Query.create().filter('Status', OperatorType.Eq, ['Pending', 'Approved'])`
Result:
`(Status eq 'Pending' or Status eq 'Approved')`